### PR TITLE
Remove myself from maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,3 @@
-Andrey Kuzmin <unsoundscapes@gmail.com>
 Arpad Ryszka <arpad.ryszka@zalando.de>
 Kolja Wilcke <kolja.wilcke@zalando.de>
 Vignesh Shanmugam <vignesh.shanmugam@zalando.de>


### PR DESCRIPTION
Because Zalando deleted the game from its 404 page, and I (the top contributor) don't work at Zalando anymore, I chose to support my own fork of the game here: https://github.com/w0rm/elm-street-404.

Depending on how interested is Zalando in this game, you may:

* fully transfer the repo to my account, please get in touch [with me on Twitter](http://twitter.com/unsoundscapes);
* update README.md with a [link to the active fork](https://github.com/w0rm/elm-street-404);
* do nothing about this